### PR TITLE
10.0.5 Update

### DIFF
--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -8,7 +8,6 @@ local Debuffs = LMB:Group("Blizzard Buffs", "Debuffs")
 if AuraButtonMixin then
 	-- Dragonflight+
 	local skinned = {}
-	local f = CreateFrame("Frame")
 
 	local function makeHook(group, container)
 		local function updateFrames(frames)

--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -11,12 +11,12 @@ if AuraButtonMixin then
 	local f = CreateFrame("Frame")
 
 	local function makeHook(group, container)
-		local function updateFrames(frames) 
+		local function updateFrames(frames)
 			for i = 1, #frames do
 				local frame = frames[i]
 				if not skinned[frame] then
 					skinned[frame] = 1
-					
+
 					-- We have to make a wrapper to hold the skinnable components of the Icon
 					-- because the aura frames are not square (and so if we skinned them directly
 					-- with Masque, they'd get all distorted and weird).
@@ -41,7 +41,7 @@ if AuraButtonMixin then
 						frame.count:SetParent(skinWrapper);
 					end
 					if frame.Border then
-						-- only debuffs have borders
+						-- only debuffs and enchants have borders
 						frame.Border:SetParent(skinWrapper);
 					end
 					if frame.symbol then
@@ -50,7 +50,7 @@ if AuraButtonMixin then
 						frame.symbol:SetParent(skinWrapper);
 					end
 					group:AddButton(skinWrapper, {
-						Icon = frame.SkinnedIcon, 
+						Icon = frame.SkinnedIcon,
 						Border = frame.Border,
 						Count = frame.count,
 						HotKey = frame.symbol
@@ -58,7 +58,7 @@ if AuraButtonMixin then
 				end
 			end
 		end
-		
+
 		return function(self)
 			updateFrames(self.auraFrames, group)
 			if self.exampleAuraFrames then
@@ -66,6 +66,7 @@ if AuraButtonMixin then
 			end
 		end
 	end
+
 	hooksecurefunc(BuffFrame, "UpdateAuraButtons", makeHook(Buffs, BuffFrame))
 	hooksecurefunc(BuffFrame, "OnEditModeEnter", makeHook(Buffs, BuffFrame))
 	hooksecurefunc(DebuffFrame, "UpdateAuraButtons", makeHook(Debuffs, DebuffFrame))
@@ -85,7 +86,7 @@ else
 			end
 			if not buff then break end
 		end
-		
+
 		for i=1, BUFF_MAX_DISPLAY do
 			local debuff = _G["DebuffButton"..i]
 			if debuff then
@@ -93,7 +94,7 @@ else
 			end
 			if not debuff then break end
 		end
-		
+
 		for i=1, (NUM_TEMP_ENCHANT_FRAMES or 3) do
 			local f = _G["TempEnchant"..i]
 			--_G["TempEnchant"..i.."Border"].SetTexture = NULL
@@ -102,10 +103,9 @@ else
 			end
 			_G["TempEnchant"..i.."Border"]:SetVertexColor(.75, 0, 1)
 		end
-		
+
 		f:SetScript("OnEvent", nil)
 	end
-
 
 	hooksecurefunc("CreateFrame", function (_, name, parent) --dont need to do this for TempEnchant enchant frames because they are hard created in xml
 		if parent ~= BuffFrame or type(name) ~= "string" then return end
@@ -118,8 +118,7 @@ else
 		end
 	end
 	)
-		
+
 	f:SetScript("OnEvent", OnEvent)
 	f:RegisterEvent("PLAYER_ENTERING_WORLD")
-
 end

--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -1,5 +1,5 @@
 
-local LMB = LibStub("Masque", true) or (LibMasque and LibMasque("Button"))
+local LMB = LibStub("Masque", true)
 if not LMB then return end
 
 local Buffs = LMB:Group("Blizzard Buffs", "Buffs")

--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -35,25 +35,35 @@ if AuraButtonMixin then
 						frame.SkinnedIcon:SetTexture(tex)
 					end)
 
-					if frame.count then
+					if frame.Count then
 						-- edit mode versions don't have stack text
-						frame.count:SetParent(skinWrapper);
+						frame.Count:SetParent(skinWrapper);
 					end
-					if frame.Border then
-						-- only debuffs and enchants have borders
-						frame.Border:SetParent(skinWrapper);
+					if frame.DebuffBorder then
+						frame.DebuffBorder:SetParent(skinWrapper);
 					end
-					if frame.symbol then
+					if frame.TempEnchantBorder then
+						frame.TempEnchantBorder:SetParent(skinWrapper);
+						frame.TempEnchantBorder:SetVertexColor(.75, 0, 1)
+					end
+					if frame.Symbol then
 						-- Shows debuff types as text in colorblind mode (except it currently doesnt work)
-						-- only debuffs have symbol
-						frame.symbol:SetParent(skinWrapper);
+						frame.Symbol:SetParent(skinWrapper);
 					end
+
+					local bType = frame.auraType or "Aura"
+
+					if bType == "DeadlyDebuff" then
+						bType = "Debuff"
+					end
+
 					group:AddButton(skinWrapper, {
 						Icon = frame.SkinnedIcon,
-						Border = frame.Border,
-						Count = frame.count,
-						HotKey = frame.symbol
-					}, "Aura")
+						DebuffBorder = frame.DebuffBorder,
+						EnchantBorder = frame.TempEnchantBorder,
+						Count = frame.Count,
+						HotKey = frame.Symbol
+					}, bType)
 				end
 			end
 		end

--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -53,7 +53,7 @@ if AuraButtonMixin then
 						Border = frame.Border,
 						Count = frame.count,
 						HotKey = frame.symbol
-					})
+					}, "Aura")
 				end
 			end
 		end
@@ -81,7 +81,7 @@ else
 		for i=1, BUFF_MAX_DISPLAY do
 			local buff = _G["BuffButton"..i]
 			if buff then
-				Buffs:AddButton(buff)
+				Buffs:AddButton(buff, nil, "Buff")
 			end
 			if not buff then break end
 		end
@@ -89,7 +89,7 @@ else
 		for i=1, BUFF_MAX_DISPLAY do
 			local debuff = _G["DebuffButton"..i]
 			if debuff then
-				Debuffs:AddButton(debuff)
+				Debuffs:AddButton(debuff, nil, "Debuff")
 			end
 			if not debuff then break end
 		end
@@ -98,7 +98,7 @@ else
 			local f = _G["TempEnchant"..i]
 			--_G["TempEnchant"..i.."Border"].SetTexture = NULL
 			if TempEnchant then
-				TempEnchant:AddButton(f)
+				TempEnchant:AddButton(f, nil, "Enchant")
 			end
 			_G["TempEnchant"..i.."Border"]:SetVertexColor(.75, 0, 1)
 		end
@@ -109,10 +109,10 @@ else
 	hooksecurefunc("CreateFrame", function (_, name, parent) --dont need to do this for TempEnchant enchant frames because they are hard created in xml
 		if parent ~= BuffFrame or type(name) ~= "string" then return end
 		if strfind(name, "^DebuffButton%d+$") then
-			Debuffs:AddButton(_G[name])
+			Debuffs:AddButton(_G[name], nil, "Debuff")
 			Debuffs:ReSkin() -- Needed to prevent issues with stack text appearing under the frame.
 		elseif strfind(name, "^BuffButton%d+$") then
-			Buffs:AddButton(_G[name])
+			Buffs:AddButton(_G[name], nil, "Buff")
 			Buffs:ReSkin() -- Needed to prevent issues with stack text appearing under the frame.
 		end
 	end

--- a/BlizzBuffsFacade.toc
+++ b/BlizzBuffsFacade.toc
@@ -1,4 +1,4 @@
-## Interface: 100000
+## Interface: 100005
 ## Title: Masque Skinner: Blizz Buffs
 ## Version: 9.0.3
 ## Author: Cybeloras of Aerie Peak

--- a/BlizzBuffsFacade_Wrath.toc
+++ b/BlizzBuffsFacade_Wrath.toc
@@ -1,4 +1,4 @@
-## Interface: 30400
+## Interface: 30401
 ## Title: Masque Skinner: Blizz Buffs
 ## Version: 9.0.1
 ## Author: Cybeloras of Aerie Peak


### PR DESCRIPTION
If you don't want the pull request, feel free to just delete it, but I do recommend that you at least make the change in 3ef0306, as it's causing some issues, like the count not being skinned. This PR does the following:

- Removes some wild spaces.
- Removes the reference to `LibMasque` which hasn't existed since 4.something.
- Removes a frame created in the Dragonflight section that's never used.
- Most importantly, it passes the base type to ensure that the buttons are skinned as Aura buttons rather than Action buttons.