### PR TITLE
Workaround to stop comparison that uses secret data to get aura type

### DIFF
--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -48,12 +48,19 @@ if AuraButtonMixin then
 								-- WoW Midnight+ - convert atlas that can't be skinned into vertex color
 								local texture
 								hooksecurefunc(frame.DebuffBorder, "SetAtlas", function(self, atlas)
-									for type, info in pairs(AuraUtil.GetDebuffDisplayInfoTable()) do
-										if atlas == info.dispelAtlas or atlas == info.basicAtlas then
-											self:SetVertexColor(info.color:GetRGB())
-											self:SetTexture(texture)
-											break
-										end
+									-- The 'atlas' argument is tainted and cannot be used in comparisons.
+									-- We can get the aura type from the aura frame itself.
+									local skinWrapper = self:GetParent()
+									if not skinWrapper then return end
+									
+									local auraFrame = skinWrapper:GetParent()
+									if not auraFrame or not auraFrame.auraType then return end
+
+									local debuffInfo = AuraUtil.GetDebuffDisplayInfoTable()[auraFrame.auraType]
+
+									if debuffInfo and debuffInfo.color then
+										self:SetVertexColor(debuffInfo.color:GetRGB())
+										self:SetTexture(texture)
 									end
 								end)
 								hooksecurefunc(frame.DebuffBorder, "SetTexture", function(self, tex)

--- a/BlizzBuffsFacade.lua
+++ b/BlizzBuffsFacade.lua
@@ -60,7 +60,7 @@ if AuraButtonMixin then
 
 									if debuffInfo and debuffInfo.color then
 										self:SetVertexColor(debuffInfo.color:GetRGB())
-										self:SetTexture(texture)
+										if texture then self:SetTexture(texture) end
 									end
 								end)
 								hooksecurefunc(frame.DebuffBorder, "SetTexture", function(self, tex)


### PR DESCRIPTION
Myself [and others](https://github.com/ascott18/Masque-Skinner-Blizz-Buffs/issues/15) have encountered an issue where MSBB is causing some bugs because it tries to access secret information.

I forked your repo and reproduced the error. I did a little video showing the fix in action. Instead of doing a comparison with secret data, I just got the aura type directly.

[Reproducing the error](https://www.youtube.com/watch?v=d3liXX4rPDs)

```sh
local skinWrapper = self:GetParent()
if not skinWrapper then return end
									
local auraFrame = skinWrapper:GetParent()
if not auraFrame or not auraFrame.auraType then return end

local debuffInfo = AuraUtil.GetDebuffDisplayInfoTable()[auraFrame.auraType]

if debuffInfo and debuffInfo.color then
	self:SetVertexColor(debuffInfo.color:GetRGB())
	if texture then self:SetTexture(texture) end
end
```